### PR TITLE
Readme fix

### DIFF
--- a/charts/synapse/README.md
+++ b/charts/synapse/README.md
@@ -31,7 +31,7 @@ This will create a postgres database, initialize the matrix database, and run th
 kubectl -n synapse port-forward svc/synapse 8080:80
 ```
 
-Then browse to [http://localhost:8080](http://localhost:8080] in your browser to see the startup page.
+Then browse to [http://localhost:8080](http://localhost:8080) in your browser to see the startup page.
 
 ## A Warning About Secrets
 

--- a/charts/synapse/README.md.gotmpl
+++ b/charts/synapse/README.md.gotmpl
@@ -30,7 +30,7 @@ This will create a postgres database, initialize the matrix database, and run th
 kubectl -n synapse port-forward svc/synapse 8080:80
 ```
 
-Then browse to [http://localhost:8080](http://localhost:8080] in your browser to see the startup page.
+Then browse to [http://localhost:8080](http://localhost:8080) in your browser to see the startup page.
 
 ## A Warning About Secrets
 

--- a/charts/synapse/values.yaml
+++ b/charts/synapse/values.yaml
@@ -113,7 +113,7 @@ ingress:
   enabled: false
   # ingress.annotations -- Annotations to add to the synapse server ingress
   annotations:
-    kubernetes.io/ingress.class: nginx-ingress
+    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
   # ingress.hosts -- A list of hosts and paths to use for the synapse ingress
   hosts:

--- a/charts/synapse/values.yaml
+++ b/charts/synapse/values.yaml
@@ -113,7 +113,7 @@ ingress:
   enabled: false
   # ingress.annotations -- Annotations to add to the synapse server ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: nginx-ingress
     cert-manager.io/cluster-issuer: letsencrypt-prod
   # ingress.hosts -- A list of hosts and paths to use for the synapse ingress
   hosts:


### PR DESCRIPTION
I originally expected to need more fixes to this, else i probably wouldn't have made this PR, but i still think this change would make it significantly easier for new people to use.

The main change is changing the ingress class from `nginx-ingress` which doesn't work on a system with ingress-nginx installed.
An example to test this would be a kind setup with ingress-nginx installed like in [this](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx) documentation.
This documentation recommends using [this](https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml) deployment file.

This PR also fixes a typo in the README.