### PR TITLE
Make a daemonset option

### DIFF
--- a/charts/stress/Chart.yaml
+++ b/charts/stress/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress
 description: A Helm chart for Stress
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"

--- a/charts/stress/README.md
+++ b/charts/stress/README.md
@@ -11,6 +11,9 @@ Set the `stressCmd` to a command that you might run with stress, such as `stress
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| daemonset.enabled | bool | `false` | If True, will be run as a daemonset. Not recommended to set true along with deployment.enabled |
+| deployment.enabled | bool | `true` | If true, will be deployed as a deployment. Not recommended to set true along with daemonset.enabled |
+| deployment.replicaCount | int | `1` | The number of replicas to run. Only affects deployments. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` | The pullPolicy. Usually best set to Always |
 | image.repository | string | `"ubuntu"` | The image repository. Probably don't change this unless you know what's going on here. |
@@ -20,7 +23,6 @@ Set the `stressCmd` to a command that you might run with stress, such as `stress
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{"fsGroup":0}` | This is intentionally insecure in order to accomodate how this chart runs. |
-| replicaCount | int | `1` | The number of replicas to run |
 | resources | object | `{}` | How you set this will largely depend on how you want to use this chart. |
 | securityContext | object | `{"readOnlyRootFilesystem":false,"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0}` | This is intentionally insecure in order to accomodate how this chart runs. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/stress/templates/daemonset.yaml
+++ b/charts/stress/templates/daemonset.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.daemonset.enabled }}
 apiVersion: apps/v1
-kind: Daemonset
+kind: DaemonSet
 metadata:
   name: {{ include "stress.fullname" . }}
   labels:

--- a/charts/stress/templates/daemonset.yaml
+++ b/charts/stress/templates/daemonset.yaml
@@ -1,12 +1,11 @@
-{{- if .Values.deployment.enabled }}
+{{- if .Values.daemonset.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: Daemonset
 metadata:
   name: {{ include "stress.fullname" . }}
   labels:
     {{- include "stress.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "stress.selectorLabels" . | nindent 6 }}

--- a/charts/stress/values.yaml
+++ b/charts/stress/values.yaml
@@ -1,5 +1,12 @@
-# -- The number of replicas to run
-replicaCount: 1
+deployment:
+  # -- If true, will be deployed as a deployment. Not recommended to set true along with daemonset.enabled
+  enabled: true
+  # -- The number of replicas to run. Only affects deployments.
+  replicaCount: 1
+
+daemonset:
+  # -- If True, will be run as a daemonset. Not recommended to set true along with deployment.enabled
+  enabled: false
 
 # -- The stress command to run, with all of the flags. Try stress -c 1
 stressCmd: 'stress --help'


### PR DESCRIPTION
this is a terrible way to do this, but it works right now. Technically it is still possible to run deployement and daemonset, but they will share affinity rules, so you might end up running many on the same node, which may be what you want.